### PR TITLE
Modifications to enable collection naming to work with meteor

### DIFF
--- a/dddp/api.py
+++ b/dddp/api.py
@@ -230,6 +230,8 @@ class CollectionMeta(APIMeta):
 
     """DDP Collection metaclass."""
 
+    model_name_map = {}
+
     def __new__(mcs, name, bases, attrs):
         """Create a new Collection class."""
         attrs.update(
@@ -240,6 +242,10 @@ class CollectionMeta(APIMeta):
             attrs.update(
                 name=model_name(model),
             )
+        if model and attrs.get('name'):
+            if model._meta.label_lower:
+                model = model._meta.label_lower
+                CollectionMeta.model_name_map.update({model: attrs.get('name')})
         return super(CollectionMeta, mcs).__new__(mcs, name, bases, attrs)
 
 
@@ -605,7 +611,11 @@ class DDP(APIMixin):
 
     def get_col_by_name(self, name):
         """Return collection instance for given name."""
-        return self._registry[COLLECTION_PATH_FORMAT.format(name=name)]
+        try:
+            return self._registry[COLLECTION_PATH_FORMAT.format(name=name)]
+        except:
+            name = Collection.model_name_map[str(name)]
+            return self._registry[COLLECTION_PATH_FORMAT.format(name=name)]
 
     def get_pub_by_name(self, name):
         """Return publication instance for given name."""

--- a/dddp/models.py
+++ b/dddp/models.py
@@ -228,8 +228,12 @@ class AleaIdField(models.CharField):
     def get_seeded_value(self, instance):
         """Generate a syncronised value."""
         # Django model._meta is public API -> pylint: disable=W0212
+        if hasattr(instance, "meteor_collection"):
+            name = instance.meteor_collection
+        else:
+            name = instance._meta
         return meteor_random_id(
-            '/collection/%s' % instance._meta, self.max_length,
+            '/collection/%s' % name, self.max_length,
         )
 
     def get_pk_value_on_save(self, instance):


### PR DESCRIPTION
I had to make these modifications to get this app to work properly without modification to meteor client. 

https://github.com/cxhandley/django-ddp-todos

Not sure if I am not doing things 100% correctly.

Modification was made to api.py as I was getting an error because model._meta couldn't find the collection in self._registry[COLLECTION_PATH_FORMAT.format(name=name)]

The modification to models.py was make because Alea was getting created using collection/django_todos.list/ instead of collection/lists/ causing a mismatch with the client. So I created a field on the model to pass the correct collection name (not ideal)

There might be a better way, i.e. changing something on _meta to make things easier.
