### PR TITLE
Property serialization

### DIFF
--- a/dddp/api.py
+++ b/dddp/api.py
@@ -494,6 +494,13 @@ class Collection(APIMixin):
             fields['%s_ids' % field.name] = get_meteor_ids(
                 field.rel.to, fields.pop(field.name),
             ).values()
+
+        # run serialization for all properties
+        for o in obj.__class__.mro():
+            for attr in o.__dict__:
+                if isinstance(o.__dict__[attr], property):
+                    val = o.__dict__[attr].__get__(obj)
+                    fields[attr] = val
         return data
 
     def obj_change_as_msg(self, obj, msg, meteor_ids=None):


### PR DESCRIPTION
I mentioned this in my issue I submitted: I'm not sure this is how you would implement this, or if even it's useful to anyone else, but I wanted to be able to apply a decorator to model method to flag it as a serializable property. These are sent along with the serialized model fields to the client.

To avoid conflict with other uses of the python property decorator, I created a ddp_property decorator that adds an attribute the method that marks it to be serialized. That bit is checked at the end of the serialize method.

I didn't have any luck receiving related data or annotated data through my subscriptions, so this was one solution. If there is a better way, please let me know. Thanks!
